### PR TITLE
added get_image and get_image_mut methods to canvas

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -164,7 +164,7 @@ impl<T> ImageStore<T> {
     }
 
     ///
-    /// Reallocates the image without changing the index
+    /// Reallocates the image without changing the index.
     ///
     pub fn realloc<R: Renderer<Image = T>>(
         &mut self,

--- a/src/image.rs
+++ b/src/image.rs
@@ -163,6 +163,22 @@ impl<T> ImageStore<T> {
         Ok(ImageId(self.0.insert((info, image))))
     }
 
+    ///
+    /// Reallocates the image without changing the index
+    ///
+    pub fn realloc<R: Renderer<Image = T>>(
+        &mut self,
+        renderer: &mut R,
+        id: ImageId,
+        info: ImageInfo,
+    ) -> Result<(), ErrorKind> {
+        let new = renderer.alloc_image(info)?;
+        if let Some(old) = self.0.get_mut(id.0) {
+            old.1 = new;
+        }
+        Ok(())
+    }
+
     pub fn get(&self, id: ImageId) -> Option<&T> {
         self.0.get(id.0).map(|inner| &inner.1)
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -164,7 +164,7 @@ impl<T> ImageStore<T> {
     }
 
     ///
-    /// Reallocates the image without changing the index.
+    /// Reallocates the image without changing the id.
     ///
     pub fn realloc<R: Renderer<Image = T>>(
         &mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,11 +394,8 @@ where
     ) -> Result<ImageId, ErrorKind> {
         let src = src.into();
         let size = src.dimensions();
-
         let id = self.create_image_empty(size.0, size.1, src.format(), flags)?;
-
         self.images.update(&mut self.renderer, id, src, 0, 0)?;
-
         Ok(id)
     }
 
@@ -410,7 +407,14 @@ where
         self.images.get_mut(id)
     }
 
-    pub fn realloc_image(&mut self, id: ImageId, width: usize, height: usize, format: PixelFormat, flags: ImageFlags) -> Result<(), ErrorKind> {
+    pub fn realloc_image(
+        &mut self,
+        id: ImageId,
+        width: usize,
+        height: usize,
+        format: PixelFormat,
+        flags: ImageFlags,
+    ) -> Result<(), ErrorKind> {
         let info = ImageInfo::new(flags, width, height, format);
         self.images.realloc(&mut self.renderer, id, info)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,6 +402,14 @@ where
         Ok(id)
     }
 
+    pub fn get_image(&self, id: ImageId) -> Option<&T::Image> {
+        self.images.get(id)
+    }
+
+    pub fn get_image_mut(&mut self, id: ImageId) -> Option<&mut T::Image> {
+        self.images.get_mut(id)
+    }
+
     /// Decode an image from file
     #[cfg(feature = "image-loading")]
     pub fn load_image_file<P: AsRef<FilePath>>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,7 +276,7 @@ where
 
     /// Tells the renderer to execute all drawing commands and clears the current internal state
     ///
-    /// Call this at the end of rach frame.
+    /// Call this at the end of each frame.
     pub fn flush(&mut self) {
         self.renderer.render(&self.images, &self.verts, &self.commands);
         self.commands.clear();
@@ -408,6 +408,11 @@ where
 
     pub fn get_image_mut(&mut self, id: ImageId) -> Option<&mut T::Image> {
         self.images.get_mut(id)
+    }
+
+    pub fn realloc_image(&mut self, id: ImageId, width: usize, height: usize, format: PixelFormat, flags: ImageFlags) -> Result<(), ErrorKind> {
+        let info = ImageInfo::new(flags, width, height, format);
+        self.images.realloc(&mut self.renderer, id, info)
     }
 
     /// Decode an image from file


### PR DESCRIPTION
I need this method to be able to blit with the images in the image store. I guess I only need the `get_image`, but I added the `get_image_mut` for good measure.

